### PR TITLE
Drop all modifiers from targetless sentences

### DIFF
--- a/pyConTextNLP/display/html.py
+++ b/pyConTextNLP/display/html.py
@@ -1,6 +1,7 @@
 """Module containing functions for generating various display options for pyConTextNLP"""
 import copy
 from ..utils import get_document_markups
+from ..utils import get_section_markups
 
 def __sort_by_span(nodes):
     n = copy.copy(nodes)
@@ -38,3 +39,34 @@ def mark_document_with_html(doc,colors = {"name":"red","pet":"blue"}, default_co
                                                  __sort_by_span(m.nodes()),
                                                  colors=colors,
                                                  default_color=default_color) for m in get_document_markups(doc)]))
+
+
+
+def mark_document_with_html_sections(doc,colors = {"name":"red","pet":"blue"}, default_color="black"):
+    """takes a ConTextDocument object and returns
+    a series of sections marked in HTML header tags followed by
+    HTML paragraphs with marked phrases in the
+    object highlighted with the colors coded in colors
+
+    doc: ConTextDocument
+    colors: dictionary keyed by ConText category with values valid HTML colors
+    """
+    h = """"""
+
+    for hierarchy in doc.getDocumentSections():
+        if hierarchy == 'document':
+            continue
+        for section in hierarchy:
+            h += """<h2> {0} </h2>""".format(section)
+            # print("## h2: ", section)
+        # print("#### Nodes:", context.getSectionNodes(section))
+        # print("#### Marked up sentences:", context.getSectionMarkups(section))
+    #     h += html.mark_document_with_html(context.getSectionMarkups(section),colors = colors, default_color="black")
+    #     print(h)
+    #
+            h += """<p> {0} </p>""".format(" ".join([mark_text(
+                        m.graph['__txt'], __sort_by_span(m.nodes()), colors=colors, default_color=default_color
+                    ) for m in get_section_markups(doc,section)
+                ]))
+
+    return h

--- a/pyConTextNLP/pyConTextGraph.py
+++ b/pyConTextNLP/pyConTextGraph.py
@@ -372,7 +372,6 @@ class ConTextDocument(object):
         tmp = list(zip(*edges))
         if len(tmp) > 1:
             tmp = [self.__root, tmp[1]]
-            print("tmp:", tmp)
         else:
             tmp = [self.__root]
         return tmp

--- a/pyConTextNLP/pyConTextGraph.py
+++ b/pyConTextNLP/pyConTextGraph.py
@@ -367,13 +367,13 @@ class ConTextDocument(object):
             return tmp[1]
 
     def getDocumentSections(self):
-        edges = [ (e[2]['sectionNumber'],e[1]) for e in self.__document.edges(data=True) if e[2].get("category") == "section"]
+        edges = [ (e[2]['__sectionNumber'],e[1]) for e in self.__document.edges(data=True) if e[2].get("category") == "section"]
         edges.sort()
         tmp = list(zip(*edges))
-        try:
-            tmp = tmp[1]
-            tmp.insert(0,self.__root)
-        except IndexError:
+        if len(tmp) > 1:
+            tmp = [self.__root, tmp[1]]
+            print("tmp:", tmp)
+        else:
             tmp = [self.__root]
         return tmp
 
@@ -706,7 +706,7 @@ class ConTextMarkup(nx.DiGraph):
         computes the text difference between the modifier and each modified
         target and keeps only the minimum distance relationship
 
-        Finally, we make sure that tehre are no self modifying modifiers present (e.g. "free" in
+        Finally, we make sure that there are no self modifying modifiers present (e.g. "free" in
         the phrase "free air" modifying the target "free air").
         """
         modifiers = self.getConTextModeNodes("modifier")
@@ -723,7 +723,7 @@ class ConTextMarkup(nx.DiGraph):
 
     def pruneSelfModifyingRelationships(self):
         """
-        We make sure that tehre are no self modifying modifiers present (e.g. "free" in
+        We make sure that there are no self modifying modifiers present (e.g. "free" in
         the phrase "free air" modifying the target "free air").
         modifiers = self.getConTextModeNodes("modifier")
         """

--- a/pyConTextNLP/pyConTextGraph.py
+++ b/pyConTextNLP/pyConTextGraph.py
@@ -308,7 +308,7 @@ class ConTextDocument(object):
         self.__document.add_edge(self.__currentParent,sectionLabel,category="section",__sectionNumber=self.__currentSectionNum)
         self.__currentSectionNum += 1
         if setToParent:
-            self.__currentParent = self.__document.node(sectionLabel)
+            self.__currentParent = sectionLabel
 
     def getDocument(self):
         return self.__document

--- a/pyConTextNLP/pyConTextGraph.py
+++ b/pyConTextNLP/pyConTextGraph.py
@@ -678,7 +678,23 @@ class ConTextMarkup(nx.DiGraph):
         """
         self.__prune_marks(self.nodes(data=True))
     def dropInactiveModifiers(self):
-        mnodes = [ n for n in self.getConTextModeNodes("modifier") if self.degree(n) == 0]
+        # if self.getVerbose():
+        #     print("### in dropInactiveModifiers.")
+        #     print("Raw:", self.getRawText())
+        #     print(" All modifiers:")
+        #     for n in self.getConTextModeNodes("modifier") :
+        #         print(n,self.degree(n))
+        #     print("All targets ({}):".format(self.getNumMarkedTargets()))
+        #     for n in self.getMarkedTargets() :
+        #         print(n)
+
+        if self.getNumMarkedTargets() == 0:
+            if self.getVerbose():
+                print("No targets in this sentence; dropping ALL modifiers.")
+            mnodes = self.getConTextModeNodes("modifier")
+        else:
+            mnodes = [ n for n in self.getConTextModeNodes("modifier") if self.degree(n) == 0]
+
         if self.getVerbose() and mnodes:
             print(u"dropping the following inactive modifiers")
             for mn in mnodes:

--- a/pyConTextNLP/utils.py
+++ b/pyConTextNLP/utils.py
@@ -2,7 +2,14 @@
 
 def get_document_markups(document):
     """ Given a ConTextDocument return an ordered list of the ConTextmarkup objects consistituting the document"""
-    tmp = [(e[1],e[2]['sentenceNumber']) for e in document.getDocument().edges(data=True) if  
+    tmp = [(e[1],e[2]['sentenceNumber']) for e in document.getDocument().edges(data=True) if
+           e[2].get('category') == 'markup']
+    tmp.sort(key=lambda x:x[1])
+    return [t[0] for t in tmp]
+
+def get_section_markups(document, sectionLabel):
+    """ Given a ConTextDocument and sectionLabel, return an ordered list of the ConTextmarkup objects in that section"""
+    tmp = [(e[1],e[2]['sentenceNumber']) for e in document.getDocument().out_edges(sectionLabel, data=True) if
            e[2].get('category') == 'markup']
     tmp.sort(key=lambda x:x[1])
     return [t[0] for t in tmp]
@@ -10,5 +17,3 @@ def get_document_markups(document):
 def conceptInDocument(document, concept):
     """tests whether concept is in any nodes of document"""
     pass
-
-


### PR DESCRIPTION
For the first commit, I think I'm understanding the desired behavior here... I explored it with the commented-out section and added the "remove them all" logic. I'm sorry I don't have tests for it; I'm a total beginner at python.

In the second, the `getDocumentSections()` routine was preventing XMLization so I think I fixed it, but am unsure how the section feature is supposed to work. I think it will be essential to be able to treat concepts differently by separating, for example, 'FAMILY HISTORY' from 'ASSESSMENT'.  Also I added section support to the HTML formatter and fixed a bug that was breaking `insertSection()` with `setToParent=True` turned on.

Sorry these are all in one ball of wax... feel free to cherry-pick, ignore or redo them.
